### PR TITLE
Update to support eventsourcing v9.1.0

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -8,12 +8,14 @@ repository = { type = "github", user = "renatillas", repo = "eventsourcing_sqlit
 
 [dependencies]
 gleam_stdlib = ">= 0.53.0 and < 2.0.0"
-eventsourcing = ">= 7.0.0 and < 8.0.0"
+eventsourcing = ">= 9.1.0 and < 10.0.0"
 sqlight = ">= 1.0.0 and < 2.0.0"
 gleam_json = ">= 3.0.2 and < 4.0.0"
+gleam_time = ">= 1.7.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.2.0 and < 2.0.0"
 birdie = ">= 1.2.5 and < 2.0.0"
 pprint = ">= 1.0.4 and < 2.0.0"
 gleam_otp = ">= 1.0.0 and < 2.0.0"
+gleam_erlang = ">= 1.3.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -6,7 +6,7 @@ packages = [
   { name = "birdie", version = "1.4.0", build_tools = ["gleam"], requirements = ["argv", "edit_distance", "filepath", "glance", "gleam_community_ansi", "gleam_stdlib", "justin", "rank", "simplifile", "term_size", "trie_again"], otp_app = "birdie", source = "hex", outer_checksum = "28F6E2F195EFB637FBBE001DD67CF34B511C5BED8921956879D29928470CFAE2" },
   { name = "edit_distance", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "edit_distance", source = "hex", outer_checksum = "A1E485C69A70210223E46E63985FA1008B8B2DDA9848B7897469171B29020C05" },
   { name = "esqlite", version = "0.8.9", build_tools = ["rebar3"], requirements = [], otp_app = "esqlite", source = "hex", outer_checksum = "465AE9AE28AE4192EA54C829FDC90C320447D439A9B2E10946621672FC6A6F8C" },
-  { name = "eventsourcing", version = "7.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time"], otp_app = "eventsourcing", source = "hex", outer_checksum = "0C441FCB5CAFEE7993CBF8FA8500E3A657687FC9E7A3D7D76BD8216BB3F1113A" },
+  { name = "eventsourcing", version = "9.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time"], otp_app = "eventsourcing", source = "hex", outer_checksum = "02E6606DD4E0F0430E89951C665824F41288170785B6F540176E1690EAF82557" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "glam", version = "2.0.3", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glam", source = "hex", outer_checksum = "237C2CE218A2A0A5D46D625F8EF5B78F964BC91018B78D692B17E1AB84295229" },
   { name = "glance", version = "5.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "FAA3DAC74AF71D47C67D88EB32CE629075169F878D148BB1FF225439BE30070A" },
@@ -17,7 +17,7 @@ packages = [
   { name = "gleam_otp", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "7987CBEBC8060B88F14575DEF546253F3116EBE2A5DA6FD82F38243FCE97C54B" },
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "0.62.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "0080706D3A5A9A36C40C68481D1D231D243AF602E6D2A2BE67BA8F8F4DFF45EC" },
-  { name = "gleam_time", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "DCDDC040CE97DA3D2A925CDBBA08D8A78681139745754A83998641C8A3F6587E" },
+  { name = "gleam_time", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56DB0EF9433826D3B99DB0B4AF7A2BFED13D09755EC64B1DAAB46F804A9AD47D" },
   { name = "gleeunit", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "FDC68A8C492B1E9B429249062CD9BAC9B5538C6FBF584817205D0998C42E1DAC" },
   { name = "glexer", version = "2.2.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "5C235CBDF4DA5203AD5EAB1D6D8B456ED8162C5424FE2309CFFB7EF438B7C269" },
   { name = "justin", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "justin", source = "hex", outer_checksum = "7FA0C6DB78640C6DC5FBFD59BF3456009F3F8B485BF6825E97E1EB44E9A1E2CD" },
@@ -31,10 +31,12 @@ packages = [
 
 [requirements]
 birdie = { version = ">= 1.2.5 and < 2.0.0" }
-eventsourcing = { version = ">= 7.0.0 and < 8.0.0" }
+eventsourcing = { version = ">= 9.1.0 and < 10.0.0" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
 gleam_json = { version = ">= 3.0.2 and < 4.0.0" }
 gleam_otp = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.53.0 and < 2.0.0" }
+gleam_time = { version = ">= 1.7.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.2.0 and < 2.0.0" }
 pprint = { version = ">= 1.0.4 and < 2.0.0" }
 sqlight = { version = ">= 1.0.0 and < 2.0.0" }

--- a/src/eventsourcing_sqlite.gleam
+++ b/src/eventsourcing_sqlite.gleam
@@ -7,6 +7,7 @@ import gleam/option.{None}
 import gleam/pair
 import gleam/result
 import gleam/string
+import gleam/time/timestamp
 import sqlight
 
 // CONSTANTS ----
@@ -404,7 +405,7 @@ fn load_snapshot(
       aggregate_id:,
       sequence:,
       entity:,
-      timestamp:,
+      timestamp: timestamp.from_unix_seconds(timestamp),
     ))
   }
 
@@ -435,6 +436,7 @@ fn save_snapshot(
 ) {
   let eventsourcing.Snapshot(aggregate_id, entity, sequence, timestamp) =
     snapshot
+  let #(seconds, _) = timestamp.to_unix_seconds_and_nanoseconds(timestamp)
   sqlight.query(
     save_snapshot_query,
     on: tx,
@@ -443,7 +445,7 @@ fn save_snapshot(
       sqlight.text(aggregate_id),
       sqlight.int(sequence),
       sqlight.text(entity |> sqlite_store.entity_encoder),
-      sqlight.int(timestamp),
+      sqlight.int(seconds),
     ],
     expecting: decode.dynamic,
   )
@@ -454,13 +456,5 @@ fn save_snapshot(
 }
 
 fn execute_in_transaction(connection_string: String) {
-  fn(f) {
-    let f = fn(db) {
-      f(db) |> result.map_error(fn(error) { string.inspect(error) })
-    }
-    sqlight.with_connection(connection_string, f)
-    |> result.map_error(fn(error) {
-      eventsourcing.EventStoreError(string.inspect(error))
-    })
-  }
+  fn(f) { sqlight.with_connection(connection_string, f) }
 }

--- a/test/eventsourcing_sqlite_test.gleam
+++ b/test/eventsourcing_sqlite_test.gleam
@@ -1,10 +1,17 @@
 import eventsourcing
 import eventsourcing_sqlite
 import example_bank_account
+import gleam/erlang/process
 import gleam/option.{type Option, None, Some}
+import gleam/otp/static_supervisor
+import gleam/time/timestamp
 import gleeunit
 import gleeunit/should
 import sqlight
+
+const recv_timeout = 5000
+
+const db_connection = "file:testdb?mode=memory&cache=shared"
 
 pub fn main() {
   gleeunit.main()
@@ -12,7 +19,7 @@ pub fn main() {
 
 fn sqlite_store() {
   eventsourcing_sqlite.new(
-    sqlight_connection_string: "test.db",
+    sqlight_connection_string: db_connection,
     event_encoder: example_bank_account.event_encoder,
     event_decoder: example_bank_account.event_decoder(),
     event_type: example_bank_account.bank_account_event_type,
@@ -29,154 +36,188 @@ fn delete_from_db(table, connection) {
 
 pub fn sqlite_store_test() {
   let sqlite_store = sqlite_store()
+
+  let assert Ok(db) = sqlight.open(db_connection)
+
+  let name = process.new_name("test_eventsourcing")
+  let query_name = process.new_name("test_query")
   let query = fn(_, _) { Nil }
+  let assert Ok(freq) = eventsourcing.frequency(1)
 
   eventsourcing_sqlite.create_event_table(sqlite_store.eventstore)
   |> should.be_ok
   eventsourcing_sqlite.create_snapshot_table(sqlite_store.eventstore)
   |> should.be_ok
 
-  let event_sourcing =
-    eventsourcing.new(
-      sqlite_store,
-      [query],
-      example_bank_account.handle,
-      example_bank_account.apply,
-      example_bank_account.BankAccount(opened: False, balance: 0.0),
+  let assert Ok(spec) =
+    eventsourcing.supervised(
+      name: name,
+      eventstore: sqlite_store,
+      handle: example_bank_account.handle,
+      apply: example_bank_account.apply,
+      empty_state: example_bank_account.BankAccount(opened: False, balance: 0.0),
+      queries: [#(query_name, query)],
+      snapshot_config: Some(eventsourcing.SnapshotConfig(freq)),
     )
 
-  let assert Ok(db) = sqlight.open("test.db")
+  let assert Ok(_) =
+    static_supervisor.new(static_supervisor.OneForOne)
+    |> static_supervisor.add(spec)
+    |> static_supervisor.start()
+
+  let actor = process.named_subject(name)
+
+  happy_path(actor)
   delete_from_db("event", db)
   |> should.be_ok()
   delete_from_db("snapshot", db)
   |> should.be_ok()
 
-  happy_path(event_sourcing)
-  delete_from_db("event", db)
-  |> should.be_ok()
-
-  load_events(event_sourcing)
-  delete_from_db("event", db)
-  |> should.be_ok()
-
-  snapshots_happy_path(event_sourcing)
+  load_events(actor)
   delete_from_db("event", db)
   |> should.be_ok()
   delete_from_db("snapshot", db)
   |> should.be_ok()
 
-  snapshot_edge_cases(event_sourcing)
+  snapshots_happy_path(actor)
   delete_from_db("event", db)
   |> should.be_ok()
   delete_from_db("snapshot", db)
   |> should.be_ok()
 
-  snapshot_error_cases(event_sourcing, sqlite_store.eventstore)
+  snapshot_edge_cases(actor)
+  delete_from_db("event", db)
+  |> should.be_ok()
+  delete_from_db("snapshot", db)
+  |> should.be_ok()
+
+  snapshot_error_cases(actor, sqlite_store.eventstore)
   delete_from_db("event", db)
   |> should.be_ok()
   delete_from_db("snapshot", db)
   |> should.be_ok()
 }
 
-fn happy_path(event_sourcing) {
-  eventsourcing.execute(
-    event_sourcing,
+fn happy_path(actor) {
+  eventsourcing.execute_with_response(
+    actor,
     "92085b42-032c-4d7a-84de-a86d67123858",
     example_bank_account.OpenAccount("92085b42-032c-4d7a-84de-a86d67123858"),
+    [],
   )
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_ok
   |> should.equal(Nil)
 
-  eventsourcing.execute(
-    event_sourcing,
-    "92085b42-032c-4d7a-84de-a86d67123858",
-    example_bank_account.DepositMoney(10.0),
-  )
-  |> should.be_ok
-  |> should.equal(Nil)
-
-  eventsourcing.execute(
-    event_sourcing,
-    "92085b42-032c-4d7a-84de-a86d67123858",
-    example_bank_account.WithDrawMoney(5.99),
-  )
-  |> should.be_ok
-  |> should.equal(Nil)
-
-  eventsourcing.load_aggregate(
-    event_sourcing,
-    "92085b42-032c-4d7a-84de-a86d67123858",
-  )
-  |> should.be_ok
-}
-
-fn load_events(event_sourcing) {
-  eventsourcing.execute_with_metadata(
-    event_sourcing,
-    "92085b42-032c-4d7a-84de-a86d67123858",
-    example_bank_account.OpenAccount("92085b42-032c-4d7a-84de-a86d67123858"),
-    [#("meta", "data")],
-  )
-  |> should.be_ok
-  |> should.equal(Nil)
-
-  eventsourcing.execute_with_metadata(
-    event_sourcing,
+  eventsourcing.execute_with_response(
+    actor,
     "92085b42-032c-4d7a-84de-a86d67123858",
     example_bank_account.DepositMoney(10.0),
     [],
   )
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_ok
   |> should.equal(Nil)
 
-  eventsourcing.execute(
-    event_sourcing,
+  eventsourcing.execute_with_response(
+    actor,
     "92085b42-032c-4d7a-84de-a86d67123858",
     example_bank_account.WithDrawMoney(5.99),
+    [],
   )
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_ok
   |> should.equal(Nil)
 
-  eventsourcing.load_events(
-    event_sourcing,
-    "92085b42-032c-4d7a-84de-a86d67123858",
-  )
+  eventsourcing.load_aggregate(actor, "92085b42-032c-4d7a-84de-a86d67123858")
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_ok
 }
 
-fn snapshots_happy_path(event_sourcing) {
-  let event_sourcing =
-    event_sourcing
-    |> eventsourcing.with_snapshots(eventsourcing.SnapshotConfig(1))
-
-  eventsourcing.execute(
-    event_sourcing,
+fn load_events(actor) {
+  eventsourcing.execute_with_response(
+    actor,
     "92085b42-032c-4d7a-84de-a86d67123858",
     example_bank_account.OpenAccount("92085b42-032c-4d7a-84de-a86d67123858"),
+    [#("meta", "data")],
   )
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_ok
   |> should.equal(Nil)
 
-  eventsourcing.execute(
-    event_sourcing,
+  eventsourcing.execute_with_response(
+    actor,
     "92085b42-032c-4d7a-84de-a86d67123858",
     example_bank_account.DepositMoney(10.0),
+    [],
   )
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_ok
   |> should.equal(Nil)
 
-  eventsourcing.execute(
-    event_sourcing,
+  eventsourcing.execute_with_response(
+    actor,
     "92085b42-032c-4d7a-84de-a86d67123858",
     example_bank_account.WithDrawMoney(5.99),
+    [],
   )
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_ok
   |> should.equal(Nil)
 
-  eventsourcing.get_latest_snapshot(
-    event_sourcing,
+  eventsourcing.load_events(actor, "92085b42-032c-4d7a-84de-a86d67123858")
+  |> process.receive(recv_timeout)
+  |> should.be_ok
+  |> should.be_ok
+}
+
+fn snapshots_happy_path(actor) {
+  eventsourcing.execute_with_response(
+    actor,
     "92085b42-032c-4d7a-84de-a86d67123858",
+    example_bank_account.OpenAccount("92085b42-032c-4d7a-84de-a86d67123858"),
+    [],
   )
+  |> process.receive(recv_timeout)
+  |> should.be_ok
+  |> should.be_ok
+  |> should.equal(Nil)
+
+  eventsourcing.execute_with_response(
+    actor,
+    "92085b42-032c-4d7a-84de-a86d67123858",
+    example_bank_account.DepositMoney(10.0),
+    [],
+  )
+  |> process.receive(recv_timeout)
+  |> should.be_ok
+  |> should.be_ok
+  |> should.equal(Nil)
+
+  eventsourcing.execute_with_response(
+    actor,
+    "92085b42-032c-4d7a-84de-a86d67123858",
+    example_bank_account.WithDrawMoney(5.99),
+    [],
+  )
+  |> process.receive(recv_timeout)
+  |> should.be_ok
+  |> should.be_ok
+  |> should.equal(Nil)
+
+  eventsourcing.latest_snapshot(
+    actor,
+    aggregate_id: "92085b42-032c-4d7a-84de-a86d67123858",
+  )
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_ok
   |> fn(
     snapshot: Option(eventsourcing.Snapshot(example_bank_account.BankAccount)),
@@ -187,27 +228,30 @@ fn snapshots_happy_path(event_sourcing) {
   }
 }
 
-fn snapshot_edge_cases(event_sourcing) {
-  let event_sourcing =
-    event_sourcing
-    |> eventsourcing.with_snapshots(eventsourcing.SnapshotConfig(1))
-
+fn snapshot_edge_cases(actor) {
   // Test Case 1: Non-existent aggregate
-  eventsourcing.get_latest_snapshot(event_sourcing, "non-existent-id")
+  eventsourcing.latest_snapshot(actor, aggregate_id: "non-existent-id")
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.equal(Ok(None))
 
   // Test Case 2: Create and update snapshot
 
   // Open account
-  eventsourcing.execute(
-    event_sourcing,
+  eventsourcing.execute_with_response(
+    actor,
     "snapshot-test-id",
     example_bank_account.OpenAccount("snapshot-test-id"),
+    [],
   )
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_ok
 
   // First snapshot should exist
-  eventsourcing.get_latest_snapshot(event_sourcing, "snapshot-test-id")
+  eventsourcing.latest_snapshot(actor, aggregate_id: "snapshot-test-id")
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_ok
   |> fn(snapshot) {
     let assert Some(eventsourcing.Snapshot(_, entity, sequence, _)) = snapshot
@@ -217,22 +261,30 @@ fn snapshot_edge_cases(event_sourcing) {
   }
 
   // Test Case 3: Multiple updates in sequence
-  eventsourcing.execute(
-    event_sourcing,
+  eventsourcing.execute_with_response(
+    actor,
     "snapshot-test-id",
     example_bank_account.DepositMoney(100.0),
+    [],
   )
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_ok
 
-  eventsourcing.execute(
-    event_sourcing,
+  eventsourcing.execute_with_response(
+    actor,
     "snapshot-test-id",
     example_bank_account.WithDrawMoney(30.0),
+    [],
   )
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_ok
 
   // Verify final snapshot state
-  eventsourcing.get_latest_snapshot(event_sourcing, "snapshot-test-id")
+  eventsourcing.latest_snapshot(actor, aggregate_id: "snapshot-test-id")
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_ok
   |> fn(snapshot) {
     let assert Some(eventsourcing.Snapshot(_, entity, sequence, _)) = snapshot
@@ -242,49 +294,53 @@ fn snapshot_edge_cases(event_sourcing) {
   }
 
   // Test Case 4: Verify snapshot with empty metadata
-  eventsourcing.execute_with_metadata(
-    event_sourcing,
+  eventsourcing.execute_with_response(
+    actor,
     "snapshot-test-id",
     example_bank_account.DepositMoney(30.0),
     [],
   )
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_ok
 
   // Test Case 5: Verify snapshot with metadata
-  eventsourcing.execute_with_metadata(
-    event_sourcing,
+  eventsourcing.execute_with_response(
+    actor,
     "snapshot-test-id",
     example_bank_account.WithDrawMoney(20.0),
     [#("operation", "withdrawal"), #("reason", "test")],
   )
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_ok
 
   // Final state verification
-  eventsourcing.get_latest_snapshot(event_sourcing, "snapshot-test-id")
+  eventsourcing.latest_snapshot(actor, aggregate_id: "snapshot-test-id")
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_ok
   |> fn(snapshot) {
-    let assert Some(eventsourcing.Snapshot(_, entity, sequence, timestamp)) =
-      snapshot
+    let assert Some(eventsourcing.Snapshot(_, entity, sequence, ts)) = snapshot
     let assert example_bank_account.BankAccount(opened: True, balance: 80.0) =
       entity
     sequence |> should.equal(5)
-    timestamp |> should.not_equal(0)
+    ts |> should.not_equal(timestamp.unix_epoch)
   }
 }
 
 fn snapshot_error_cases(
-  event_sourcing,
+  actor,
   event_store: eventsourcing_sqlite.SqliteStore(_, _, _, _),
 ) {
-  let event_sourcing =
-    event_sourcing
-    |> eventsourcing.with_snapshots(eventsourcing.SnapshotConfig(1))
-
-  let assert Ok(db) = sqlight.open("test.db")
+  let assert Ok(db) = sqlight.open(db_connection)
   sqlight.exec("DROP TABLE snapshot", db)
   |> should.be_ok()
+
   // Test Case 1: Attempt operations before table creation
-  eventsourcing.get_latest_snapshot(event_sourcing, "error-test-id")
+  eventsourcing.latest_snapshot(actor, aggregate_id: "error-test-id")
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_error
 
   // Create tables and test error cases
@@ -296,31 +352,42 @@ fn snapshot_error_cases(
   let account_id = "error-test-id"
 
   // Test Case 2: Operations on unopened account
-  eventsourcing.execute(
-    event_sourcing,
+  eventsourcing.execute_with_response(
+    actor,
     account_id,
     example_bank_account.WithDrawMoney(100.0),
+    [],
   )
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_error
 
   // Test Case 3: Invalid operation sequence
-  eventsourcing.execute(
-    event_sourcing,
+  eventsourcing.execute_with_response(
+    actor,
     account_id,
     example_bank_account.OpenAccount(account_id),
+    [],
   )
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_ok
 
   // Attempt to withdraw more than balance
-  eventsourcing.execute(
-    event_sourcing,
+  eventsourcing.execute_with_response(
+    actor,
     account_id,
     example_bank_account.WithDrawMoney(100.0),
+    [],
   )
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_error
 
   // Verify snapshot still reflects valid state
-  eventsourcing.get_latest_snapshot(event_sourcing, account_id)
+  eventsourcing.latest_snapshot(actor, aggregate_id: account_id)
+  |> process.receive(recv_timeout)
+  |> should.be_ok
   |> should.be_ok
   |> fn(snapshot) {
     let assert Some(eventsourcing.Snapshot(_, entity, sequence, _)) = snapshot


### PR DESCRIPTION
I wanted to use eventsourcing with the sqlite backend, but saw it wasn't updated for the current version. I didn't see any activity about it on the Gleam discord so I figured I'd take a shot at it.

I'm a newbie to Gleam and don't really understand OTP, so there's a high likelihood I've made some obvious mistakes. Basically I bumped the dep and then worked through compiler errors. I'll leave some inline comments. If this does have big mistakes or you otherwise prefer to update it yourself, probably the best strategy would be closing this PR in favor of your own update.